### PR TITLE
Move classes to a namespace

### DIFF
--- a/lib/client/client.rb
+++ b/lib/client/client.rb
@@ -1,46 +1,48 @@
-# Base class for 3taps API client classes.
-class Client
-  DEFAULT_URL = 'http://3taps.net'
-  DEFAULT_API_PORT = 80
-  TIMEOUT = 15
-  # Initializes Client class with +baseUrl+ and +port+ parameters. By default 
-  # DEFAULT_URL and DEFAULT_API_PORT are used. Examples:
-  #  Client.new
-  #  Client.new("http://3taps.com", 8080)
-  def initialize(baseUrl = DEFAULT_URL, port = DEFAULT_API_PORT)
-    @baseURL = baseUrl
-    @port = port
-  end
-
-  # Executes GET request on URL and port with +path+ and +params+ parameters.
-  # Example:
-  #
-  #  execute_get("/search", "data=data")
-  def execute_get( path, params = nil )
-    address = params.nil? ? path : path + '?' + params 
-    request = Curl::Easy.new("#{@baseURL}:#{@port}" + address) 
-    begin
-      request.perform
-    rescue
-      "Some Error with Request."
+module ThreeTaps
+  # Base class for 3taps API client classes.
+  class Client
+    DEFAULT_URL = 'http://3taps.net'
+    DEFAULT_API_PORT = 80
+    TIMEOUT = 15
+    # Initializes Client class with +baseUrl+ and +port+ parameters. By default 
+    # DEFAULT_URL and DEFAULT_API_PORT are used. Examples:
+    #  Client.new
+    #  Client.new("http://3taps.com", 8080)
+    def initialize(baseUrl = DEFAULT_URL, port = DEFAULT_API_PORT)
+      @baseURL = baseUrl
+      @port = port
     end
-    request.body_str
-  end
 
-  # Executes POST request on URL and port with +path+ and +params+ parameters.
-  # Example:
-  #
-  #  execute_post("search", "data=data")
-  def execute_post( path, params = nil )
-    c = Curl::Easy.new("#{@baseURL}:#{@port}/#{path}")
-    param, data = params.split("=",2)
-    c.http_post(param.to_s + '=' + c.escape(data.to_s))
-    c.body_str
-  end
+    # Executes GET request on URL and port with +path+ and +params+ parameters.
+    # Example:
+    #
+    #  execute_get("/search", "data=data")
+    def execute_get( path, params = nil )
+      address = params.nil? ? path : path + '?' + params 
+      request = Curl::Easy.new("#{@baseURL}:#{@port}" + address) 
+      begin
+        request.perform
+      rescue
+        "Some Error with Request."
+      end
+      request.body_str
+    end
 
-  private
+    # Executes POST request on URL and port with +path+ and +params+ parameters.
+    # Example:
+    #
+    #  execute_post("search", "data=data")
+    def execute_post( path, params = nil )
+      c = Curl::Easy.new("#{@baseURL}:#{@port}/#{path}")
+      param, data = params.split("=",2)
+      c.http_post(param.to_s + '=' + c.escape(data.to_s))
+      c.body_str
+    end
 
-  def decode(data)
-    ActiveSupport::JSON.decode(data)
+    private
+
+    def decode(data)
+      ActiveSupport::JSON.decode(data)
+    end
   end
 end

--- a/lib/client/geocoder_client.rb
+++ b/lib/client/geocoder_client.rb
@@ -1,45 +1,47 @@
-# Class GeocoderClient represents server request of geocoding API (calculate
-# the location to use for a posting based on location-specific details within
-# the posting such as a street address or a latitude and longitude value).
-#
-# Its methods are used to query API with appropriate requests:
-# geocode(requests) - returns array of responses
-#
-# Example:
-#
-#  client = GeocoderClient.new
-#  request = GeocoderRequest.new
-#  request.latitude = '37.77493'
-#  request.longitude = '-122.41942'
-#
-#  response = client.geocode(request)
-#
-#  response.first.code       # => "CAZ"
-#  response.first.latitude   # => 39.77493
-#  response.first.longitude  # => -122.41942
-
-class GeocoderClient < Client
-
-  # Method geocode sends geocode request to Geocode API.
-  # Takes array of GeocoderRequest objects as +requests+ parameter.
+module ThreeTaps
+  # Class GeocoderClient represents server request of geocoding API (calculate
+  # the location to use for a posting based on location-specific details within
+  # the posting such as a street address or a latitude and longitude value).
   #
-  # Examples:
+  # Its methods are used to query API with appropriate requests:
+  # geocode(requests) - returns array of responses
   #
+  # Example:
+  #
+  #  client = GeocoderClient.new
   #  request = GeocoderRequest.new
-  #  client.geocode(request) # => [GeocoderResponse]
+  #  request.latitude = '37.77493'
+  #  request.longitude = '-122.41942'
   #
-  #  requests = [GeocoderRequest.new, GeocoderRequest.new]
-  #  client.geocode(requests) # => [GeocoderResponse, GeocoderResponse]
+  #  response = client.geocode(request)
   #
-  def geocode(geocoder_requests)
-    geocoder_requests = [geocoder_requests] unless geocoder_requests.is_a? Array
-    params = "data=["
-    params << geocoder_requests.collect{|request| "#{request.to_params}"}.join(',')
-    params << "]"
-    p params
-    response = execute_post('geocoder/geocode', params)
-    p response
-    p decode(response)
-    GeocoderResponse.from_array(decode(response))
+  #  response.first.code       # => "CAZ"
+  #  response.first.latitude   # => 39.77493
+  #  response.first.longitude  # => -122.41942
+
+  class GeocoderClient < Client
+
+    # Method geocode sends geocode request to Geocode API.
+    # Takes array of GeocoderRequest objects as +requests+ parameter.
+    #
+    # Examples:
+    #
+    #  request = GeocoderRequest.new
+    #  client.geocode(request) # => [GeocoderResponse]
+    #
+    #  requests = [GeocoderRequest.new, GeocoderRequest.new]
+    #  client.geocode(requests) # => [GeocoderResponse, GeocoderResponse]
+    #
+    def geocode(geocoder_requests)
+      geocoder_requests = [geocoder_requests] unless geocoder_requests.is_a? Array
+      params = "data=["
+      params << geocoder_requests.collect{|request| "#{request.to_params}"}.join(',')
+      params << "]"
+      p params
+      response = execute_post('geocoder/geocode', params)
+      p response
+      p decode(response)
+      GeocoderResponse.from_array(decode(response))
+    end
   end
 end

--- a/lib/client/posting_client.rb
+++ b/lib/client/posting_client.rb
@@ -1,92 +1,94 @@
-# The PostingClient class allows clients to use 3taps Posting API to store and
-# retrieve postings in the 3taps system.
-#
-# Its methods are used to query API with appropriate requests:
-#  client = PostingClient.new
-#  client.get_posting(post_key)      # => returns a single Posting object
-#  client.create_posting(postings)   # => returns array of CreateResponse objects
-#  client.update_posting(postings)   # => returns array of UpdateResponse objects
-#  client.delete_posting(post_keys)  # => returns array of DeleteResponse objects
-#  client.exists_posting(posting)    # => returns array of ExistsResponse objects
-class PostingClient < Client
+module ThreeTaps
+  # The PostingClient class allows clients to use 3taps Posting API to store and
+  # retrieve postings in the 3taps system.
+  #
+  # Its methods are used to query API with appropriate requests:
+  #  client = PostingClient.new
+  #  client.get_posting(post_key)      # => returns a single Posting object
+  #  client.create_posting(postings)   # => returns array of CreateResponse objects
+  #  client.update_posting(postings)   # => returns array of UpdateResponse objects
+  #  client.delete_posting(post_keys)  # => returns array of DeleteResponse objects
+  #  client.exists_posting(posting)    # => returns array of ExistsResponse objects
+  class PostingClient < Client
 
-  # Retrieves an information about a single posting.
-  # 
-  # Example
-  #  client = PostingClient.new
-  #  client.get_posting("...postKey string...") => Posting object
-  #
-  def get_posting(post_key)
-    response = execute_get("/posting/get/" + post_key)
-    Posting.new(decode(response))
-  end
+    # Retrieves an information about a single posting.
+    # 
+    # Example
+    #  client = PostingClient.new
+    #  client.get_posting("...postKey string...") => Posting object
+    #
+    def get_posting(post_key)
+      response = execute_get("/posting/get/" + post_key)
+      Posting.new(decode(response))
+    end
 
-  # Method +create_posting+ saves a single new posting and multiple new postings in 3taps.
-  #
-  # Examples
-  #  client = PostingClient.new
-  #  client.update_posting([posting1, posting2])  #=> Array of CreateResponse objects
-  #
-  #  client = PostingClient.new
-  #  client.update_posting(posting2)  #=> Array with single CreateResponse object
-  #
-  def create_posting(postings)
-    postings = [postings] unless postings.is_a? Array
-    data = "["
-    data << postings.collect{|posting| posting.to_json}.join(',')
-    data << "]"
-    params = "postings=#{data}"
-    p params
-    response = execute_post("/posting/create", params)
-    p response.inspect
-    p decode(response)
-    CreateResponse.from_array(decode(response))
-  end
+    # Method +create_posting+ saves a single new posting and multiple new postings in 3taps.
+    #
+    # Examples
+    #  client = PostingClient.new
+    #  client.update_posting([posting1, posting2])  #=> Array of CreateResponse objects
+    #
+    #  client = PostingClient.new
+    #  client.update_posting(posting2)  #=> Array with single CreateResponse object
+    #
+    def create_posting(postings)
+      postings = [postings] unless postings.is_a? Array
+      data = "["
+      data << postings.collect{|posting| posting.to_json}.join(',')
+      data << "]"
+      params = "postings=#{data}"
+      p params
+      response = execute_post("/posting/create", params)
+      p response.inspect
+      p decode(response)
+      CreateResponse.from_array(decode(response))
+    end
 
-  # Method +update_posting+ updates  a single posting and multiple postings on 3taps.
-  #
-  # Examples:
-  #  client = PostingClient.new
-  #  client.update_posting([posting1, posting2])  #=> Array of UpdateResponse objects
-  #
-  #  client = PostingClient.new
-  #  client.update_posting(posting)  #=> Array with single UpdateResponse object
-  #
-  def update_posting(postings)
-    postings = [postings] unless postings.is_a? Array
-    data = "["
-    data << postings.collect{|posting| posting.to_json_for_update}.join(',')
-    data << "]"
-    params = "data=#{data}"
-    response = execute_post("posting/update", params)
-    UpdateResponse.from_hash(decode(response))
-  end
+    # Method +update_posting+ updates  a single posting and multiple postings on 3taps.
+    #
+    # Examples:
+    #  client = PostingClient.new
+    #  client.update_posting([posting1, posting2])  #=> Array of UpdateResponse objects
+    #
+    #  client = PostingClient.new
+    #  client.update_posting(posting)  #=> Array with single UpdateResponse object
+    #
+    def update_posting(postings)
+      postings = [postings] unless postings.is_a? Array
+      data = "["
+      data << postings.collect{|posting| posting.to_json_for_update}.join(',')
+      data << "]"
+      params = "data=#{data}"
+      response = execute_post("posting/update", params)
+      UpdateResponse.from_hash(decode(response))
+    end
 
-  # Method +delete_posting+  deletes a single posting and multiple postings from 3taps.
-  # 
-  # Examples:
-  #  client = PostingClient.new
-  #  response = client.delete_posting(...Array of postKeys strings...)     # => Array of DeleteResponse objects
-  #
-  #  client = PostingClient.new
-  #  key = some_posting.postKey
-  #  response = client.delete_posting(key)     # => Array with single DeleteResponse object
-  #
-  def delete_posting(post_keys)
-    post_keys = [post_keys] unless post_keys.is_a? Array
-    params = "data=['#{post_keys.join("','")}']"
-    response = execute_post("posting/delete", params)
-    DeleteResponse.from_hash(decode(response))
-  end
+    # Method +delete_posting+  deletes a single posting and multiple postings from 3taps.
+    # 
+    # Examples:
+    #  client = PostingClient.new
+    #  response = client.delete_posting(...Array of postKeys strings...)     # => Array of DeleteResponse objects
+    #
+    #  client = PostingClient.new
+    #  key = some_posting.postKey
+    #  response = client.delete_posting(key)     # => Array with single DeleteResponse object
+    #
+    def delete_posting(post_keys)
+      post_keys = [post_keys] unless post_keys.is_a? Array
+      params = "data=['#{post_keys.join("','")}']"
+      response = execute_post("posting/delete", params)
+      DeleteResponse.from_hash(decode(response))
+    end
 
-  # NOT USED
-  #
-  #  Returns information on the existence of postings.
-  #
-  def exists_posting(posting)
-    params = "ids=[#{posting.to_json_for_status}]"
-    response = execute_post("/posting/exists", params)
-    p decode(response)[0]
-    ExistsResponse.new(decode(response)[0])
+    # NOT USED
+    #
+    #  Returns information on the existence of postings.
+    #
+    def exists_posting(posting)
+      params = "ids=[#{posting.to_json_for_status}]"
+      response = execute_post("/posting/exists", params)
+      p decode(response)[0]
+      ExistsResponse.new(decode(response)[0])
+    end
   end
 end

--- a/lib/client/reference_client.rb
+++ b/lib/client/reference_client.rb
@@ -1,60 +1,62 @@
-# Class ReferenceClient represents server request of reference API (provides a
-# mechanism for accessing the standard "reference information" used by the
-# 3taps system, including locations, categories, and sources).
-#
-# Its methods are used to query API with appropriate requests:
-#  client = ReferenceClient.new
-#  client.get_categories     # => returns array of Category objects
-#  client.get_category(code) # => returns Category object
-#  client.get_locations      # => returns array of Location objects
-#  client.get_sources        # => returns array of Source objects
-
-class ReferenceClient < Client
-
-  # Method +get_categories+ returns the 3taps categories.
+module ThreeTaps
+  # Class ReferenceClient represents server request of reference API (provides a
+  # mechanism for accessing the standard "reference information" used by the
+  # 3taps system, including locations, categories, and sources).
   #
-  # Example:
-  #
+  # Its methods are used to query API with appropriate requests:
   #  client = ReferenceClient.new
-  #  client.get_categories # => Array of Category
-  #
-  def get_categories
-    response = execute_get("/reference/category")
-    File.new("newfile",  "w+") << response
-    Category.from_array(decode(response))
-  end
+  #  client.get_categories     # => returns array of Category objects
+  #  client.get_category(code) # => returns Category object
+  #  client.get_locations      # => returns array of Location objects
+  #  client.get_sources        # => returns array of Source objects
 
-  # Method +get_category+ returns a single category by passing in the category code.
-  # Takes value of code objects as +String+ parameter.
-  # 
-  # Example:
-  #
-  #  client.get_category('NYC') # => Categoty
-  #
-  def get_category(code)
-    response = execute_get("/reference/category/" + code)
-    Category.from_hash(decode(response)[0])
-  end
+  class ReferenceClient < Client
 
-  # Method +get_locations+ returns the 3taps locations.
-  #
-  # Example:
-  #
-  #  client.get_locations # => Array of Location
-  #
-  def get_locations
-    response = execute_get("/reference/location")
-    Location.from_array(decode(response))
-  end
+    # Method +get_categories+ returns the 3taps categories.
+    #
+    # Example:
+    #
+    #  client = ReferenceClient.new
+    #  client.get_categories # => Array of Category
+    #
+    def get_categories
+      response = execute_get("/reference/category")
+      File.new("newfile",  "w+") << response
+      Category.from_array(decode(response))
+    end
 
-  # Method +get_sources+ returns the 3taps sources.
-  #
-  # Example:
-  #
-  #  client.get_sources # => Array of Source
-  #
-  def get_sources
-    response = execute_get("/reference/source")
-    Source.from_array(decode(response))
+    # Method +get_category+ returns a single category by passing in the category code.
+    # Takes value of code objects as +String+ parameter.
+    # 
+    # Example:
+    #
+    #  client.get_category('NYC') # => Categoty
+    #
+    def get_category(code)
+      response = execute_get("/reference/category/" + code)
+      Category.from_hash(decode(response)[0])
+    end
+
+    # Method +get_locations+ returns the 3taps locations.
+    #
+    # Example:
+    #
+    #  client.get_locations # => Array of Location
+    #
+    def get_locations
+      response = execute_get("/reference/location")
+      Location.from_array(decode(response))
+    end
+
+    # Method +get_sources+ returns the 3taps sources.
+    #
+    # Example:
+    #
+    #  client.get_sources # => Array of Source
+    #
+    def get_sources
+      response = execute_get("/reference/source")
+      Source.from_array(decode(response))
+    end
   end
 end

--- a/lib/client/search_client.rb
+++ b/lib/client/search_client.rb
@@ -1,82 +1,84 @@
-# The SearchClient class allows clients to query 3taps Search API for data,
-# and data about data.
-#
-# Its methods are used to query API with appropriate requests:
-#  client = SearchClient.new
-#  client.search(search_request)    # => returns array of SearchResponse objects
-#  client.range(range_request)      # => returns array of RangeResponse objects
-#  client.summary(summary_request)  # => returns array of SummaryResponse objects
-#  client.count(search_request)     # => returns array of CountResponse objects
-#  client.best_match(keywords)      # => returns array of BestMatchResponse objects
-class SearchClient < Client
-
-  # Method +search+ searches 3taps for postings. Example:
+module ThreeTaps
+  # The SearchClient class allows clients to query 3taps Search API for data,
+  # and data about data.
   #
-  #  request = SearchRequest.new
+  # Its methods are used to query API with appropriate requests:
   #  client = SearchClient.new
-  #  client.search(request)     # => SearchResponse
-  #
-  def search(search_request)
-    response = execute_get("/search", search_request.query_params)
-    SearchResponse.new(decode(response))
-  end
+  #  client.search(search_request)    # => returns array of SearchResponse objects
+  #  client.range(range_request)      # => returns array of RangeResponse objects
+  #  client.summary(summary_request)  # => returns array of SummaryResponse objects
+  #  client.count(search_request)     # => returns array of CountResponse objects
+  #  client.best_match(keywords)      # => returns array of BestMatchResponse objects
+  class SearchClient < Client
 
-  # Method +range+ returns the minium and maximum values currently in 3taps for
-  # the given fields that match the given Common Search Criteria inside of the
-  # RangeResponse object. The purpose of the range method is to provide
-  # developers with sensible values for range-based UI filters.
-  #
-  # Examples:
-  #
-  #  request = RangeRequest.new
-  #  client = SearchClient.new(request)
-  #  client.range(request)        # => RangeResponse
-  #
-  def range(range_request)
-    response = execute_get("/search/range", range_request.query_params)
-    RangeResponse.from_array(decode(response))
-  end
+    # Method +search+ searches 3taps for postings. Example:
+    #
+    #  request = SearchRequest.new
+    #  client = SearchClient.new
+    #  client.search(request)     # => SearchResponse
+    #
+    def search(search_request)
+      response = execute_get("/search", search_request.query_params)
+      SearchResponse.new(decode(response))
+    end
 
-  # Method +summary+ returns the total number of postings found in 3taps, across
-  # the given dimension, that match the given Common Search Criteria parameters
-  # inside of the SummaryResponse object. Searching for "text=toyota" across
-  # "dimension=source" would return a list of all sources in 3taps, along with
-  # the number of postings matching the search "text=toyota" in that source.
-  # You may currently search across dimensions source, category, and location.
-  #
-  # Examples:
-  #
-  #  request = SummaryRequest.new
-  #  client = SearchClient.new
-  #  client.summary(request)      # => SummaryResponse
-  #
-  def summary(summary_request)
-    response = execute_get("/search/summary", summary_request.query_params)
-    SummaryResponse.from_hash(decode(response))
-  end
+    # Method +range+ returns the minium and maximum values currently in 3taps for
+    # the given fields that match the given Common Search Criteria inside of the
+    # RangeResponse object. The purpose of the range method is to provide
+    # developers with sensible values for range-based UI filters.
+    #
+    # Examples:
+    #
+    #  request = RangeRequest.new
+    #  client = SearchClient.new(request)
+    #  client.range(request)        # => RangeResponse
+    #
+    def range(range_request)
+      response = execute_get("/search/range", range_request.query_params)
+      RangeResponse.from_array(decode(response))
+    end
 
-  # Method +count+ returns the total number of postings that match the given
-  # Common Search Criteria represented by SearchRequest. Example:
-  #
-  #  request = SearchRequest.new
-  #  client = SearchClient.new
-  #  client.count(request)      # => CountResponse
-  #
-  def count(search_request)
-    response = execute_get("/search/count", search_request.query_params)
-    CountResponse.new(decode(response))
-  end
+    # Method +summary+ returns the total number of postings found in 3taps, across
+    # the given dimension, that match the given Common Search Criteria parameters
+    # inside of the SummaryResponse object. Searching for "text=toyota" across
+    # "dimension=source" would return a list of all sources in 3taps, along with
+    # the number of postings matching the search "text=toyota" in that source.
+    # You may currently search across dimensions source, category, and location.
+    #
+    # Examples:
+    #
+    #  request = SummaryRequest.new
+    #  client = SearchClient.new
+    #  client.summary(request)      # => SummaryResponse
+    #
+    def summary(summary_request)
+      response = execute_get("/search/summary", summary_request.query_params)
+      SummaryResponse.from_hash(decode(response))
+    end
 
-  # Method +best_match+ returns the 3taps category associated with the keywords,
-  # along with the number of postings in that category. Example:
-  #
-  #  keywords = "iPad,Apple,iPhone"
-  #  client = SearchClient.new
-  #  client.best_match(keywords)     # => BestMatchResponse
-  # 
-  def best_match(keywords)
-    response = execute_get("/search/best-match", "keywords=#{keywords}")
-    BestMatchResponse.new(decode(response))
-  end
+    # Method +count+ returns the total number of postings that match the given
+    # Common Search Criteria represented by SearchRequest. Example:
+    #
+    #  request = SearchRequest.new
+    #  client = SearchClient.new
+    #  client.count(request)      # => CountResponse
+    #
+    def count(search_request)
+      response = execute_get("/search/count", search_request.query_params)
+      CountResponse.new(decode(response))
+    end
 
+    # Method +best_match+ returns the 3taps category associated with the keywords,
+    # along with the number of postings in that category. Example:
+    #
+    #  keywords = "iPad,Apple,iPhone"
+    #  client = SearchClient.new
+    #  client.best_match(keywords)     # => BestMatchResponse
+    # 
+    def best_match(keywords)
+      response = execute_get("/search/best-match", "keywords=#{keywords}")
+      BestMatchResponse.new(decode(response))
+    end
+
+  end
 end

--- a/lib/client/status_client.rb
+++ b/lib/client/status_client.rb
@@ -1,72 +1,74 @@
-# The StatusClient class provides access to the Status API.
-#
-# The Status API provides access to the status of postings, both inside and
-# outside of the 3taps system. The Status API is built upon the assumption that
-# most postings can be globally identified using two pieces of data: the source
-# and the externalID. Since we can globally identify a posting, we can share the
-# status of postings between various systems.
-#
-# For example, if a posting has been
-# "sent" to the Posting API by an external source, that external source can
-# optionally send a status of "sent" to the Status API. Once the Posting API has
-# processed and saved the posting, it can send the status of "saved" to the
-# Status API. Later, if somebody looks up the posting in the Status API, they
-# will see both of these events (sent and saved), along with the time that they
-# occurred, and any relevant attributes (postKey, errors, etc). Having this
-# information available allows 3taps and sources to provide maximum visibility
-# into their processes so that both can improve data yield.
-#
-# Class StatusClient provides access to the status API of postings
-# server response returns the status of postings, if a posting has been "sent" to the Posting API by an 
-# external source, that external source can optionally send a status of "sent" the Status API.
-#
-# Its methods are used to query API with appropriate requests:
-#  client = StatusClient .new
-#  client.update_status(postings)    # => returns Message
-#  client.get_status(postings)       # => returns array of GetStatusResponse objects
-#  client.system_status              # => returns Message
-#
-class StatusClient < Client
+module ThreeTaps
+  # The StatusClient class provides access to the Status API.
   #
-  # Method +update_status+ send in status events for postings. Example:
+  # The Status API provides access to the status of postings, both inside and
+  # outside of the 3taps system. The Status API is built upon the assumption that
+  # most postings can be globally identified using two pieces of data: the source
+  # and the externalID. Since we can globally identify a posting, we can share the
+  # status of postings between various systems.
   #
-  #  client = StatusClient.new
-  #  request = StatusUpdateRequest.new
-  #  client.update_status(request)             # => Message
+  # For example, if a posting has been
+  # "sent" to the Posting API by an external source, that external source can
+  # optionally send a status of "sent" to the Status API. Once the Posting API has
+  # processed and saved the posting, it can send the status of "saved" to the
+  # Status API. Later, if somebody looks up the posting in the Status API, they
+  # will see both of these events (sent and saved), along with the time that they
+  # occurred, and any relevant attributes (postKey, errors, etc). Having this
+  # information available allows 3taps and sources to provide maximum visibility
+  # into their processes so that both can improve data yield.
   #
-  def update_status(postings)
-    postings = [postings] unless postings.is_a? Array
-    params ='events=['
-    params << postings.collect{|posting| "{#{posting.status.to_params}, #{posting.to_json_for_status_client}}" unless posting.status.event.empty?}.join(',')
-    params << "]"
-    response = execute_post("status/update", params)
-    Message.from_hash(decode(response))
-  end
+  # Class StatusClient provides access to the status API of postings
+  # server response returns the status of postings, if a posting has been "sent" to the Posting API by an 
+  # external source, that external source can optionally send a status of "sent" the Status API.
   #
-  # Method +get_status+ get status history for postings. Example:
+  # Its methods are used to query API with appropriate requests:
+  #  client = StatusClient .new
+  #  client.update_status(postings)    # => returns Message
+  #  client.get_status(postings)       # => returns array of GetStatusResponse objects
+  #  client.system_status              # => returns Message
   #
-  #  client = SearchClient.new
-  #  postings = Posting.new
-  #  response = client.get_status(postings)    # => Array of GetStatusResponse 
-  #
-  def get_status(postings)
-    postings = [postings] unless postings.is_a? Array
-    data = "["
-    data << postings.collect{|posting| "{#{posting.to_json_for_status_client}}"}.join(',')
-    data << "]"
-    params = "postings=#{data}"
-    response = execute_post("status/get", params)
-    GetStatusResponse.from_array(decode(response))
-  end
-  #
-  # Method +system_status+ get the current system status. Example:
-  #
-  #  client = StatusClient.new
-  #  response = client.system_status           # => Message
-  #
-  def system_status
-    response = execute_get("/status/system")
-    Message.from_hash(decode(response))
-  end
+  class StatusClient < Client
+    #
+    # Method +update_status+ send in status events for postings. Example:
+    #
+    #  client = StatusClient.new
+    #  request = StatusUpdateRequest.new
+    #  client.update_status(request)             # => Message
+    #
+    def update_status(postings)
+      postings = [postings] unless postings.is_a? Array
+      params ='events=['
+      params << postings.collect{|posting| "{#{posting.status.to_params}, #{posting.to_json_for_status_client}}" unless posting.status.event.empty?}.join(',')
+      params << "]"
+      response = execute_post("status/update", params)
+      Message.from_hash(decode(response))
+    end
+    #
+    # Method +get_status+ get status history for postings. Example:
+    #
+    #  client = SearchClient.new
+    #  postings = Posting.new
+    #  response = client.get_status(postings)    # => Array of GetStatusResponse 
+    #
+    def get_status(postings)
+      postings = [postings] unless postings.is_a? Array
+      data = "["
+      data << postings.collect{|posting| "{#{posting.to_json_for_status_client}}"}.join(',')
+      data << "]"
+      params = "postings=#{data}"
+      response = execute_post("status/get", params)
+      GetStatusResponse.from_array(decode(response))
+    end
+    #
+    # Method +system_status+ get the current system status. Example:
+    #
+    #  client = StatusClient.new
+    #  response = client.system_status           # => Message
+    #
+    def system_status
+      response = execute_get("/status/system")
+      Message.from_hash(decode(response))
+    end
 
+  end
 end

--- a/lib/dto/geocoder/geocoder_request.rb
+++ b/lib/dto/geocoder/geocoder_request.rb
@@ -1,16 +1,18 @@
-class GeocoderRequest < Struct.new(:latitude, :longitude, :country, :state, :city, :locality, :postal, :text)
+module ThreeTaps
+  class GeocoderRequest < Struct.new(:latitude, :longitude, :country, :state, :city, :locality, :postal, :text)
 
-  def to_params
-    result = []
-    result << "\"latitude\":#{latitude}" unless latitude.nil?
-    result << "\"longitude\":#{longitude}" unless longitude.nil?
-    result << "\"country\":\"#{country}\"" unless country.nil?
-    result << "\"state\":\"#{state}\"" unless state.nil?
-    result << "\"city\":\"#{city}\"" unless city.nil?
-    result << "\"locality\":\"#{locality}\"" unless locality.nil?
-    result << "\"postal\":\"#{postal}\"" unless postal.nil?
-    result << "\"text\":\"#{text}\"" unless text.nil?
-    '{' + result.join(", ") + '}'
+    def to_params
+      result = []
+      result << "\"latitude\":#{latitude}" unless latitude.nil?
+      result << "\"longitude\":#{longitude}" unless longitude.nil?
+      result << "\"country\":\"#{country}\"" unless country.nil?
+      result << "\"state\":\"#{state}\"" unless state.nil?
+      result << "\"city\":\"#{city}\"" unless city.nil?
+      result << "\"locality\":\"#{locality}\"" unless locality.nil?
+      result << "\"postal\":\"#{postal}\"" unless postal.nil?
+      result << "\"text\":\"#{text}\"" unless text.nil?
+      '{' + result.join(", ") + '}'
+    end
+
   end
-
 end

--- a/lib/dto/geocoder/geocoder_response.rb
+++ b/lib/dto/geocoder/geocoder_response.rb
@@ -1,7 +1,9 @@
-class GeocoderResponse < Struct.new(:code, :latitude, :longitude, :errors)
-  def self.from_array(array)
-     array.collect do |geocode|
-      from_hash(:code => geocode[0], :latitude => geocode[1], :longitude => geocode[2])
+module ThreeTaps
+  class GeocoderResponse < Struct.new(:code, :latitude, :longitude, :errors)
+    def self.from_array(array)
+       array.collect do |geocode|
+        from_hash(:code => geocode[0], :latitude => geocode[1], :longitude => geocode[2])
+      end
     end
   end
 end

--- a/lib/dto/posting/create_response.rb
+++ b/lib/dto/posting/create_response.rb
@@ -1,23 +1,25 @@
-# Class CreateResponse represents server response on +create+ Posting API
-# request. Server response is sent to +from_array+ method which creates objects
-# with attributes +postKey+, +error+ accessible via getters:
-#
-#  response = RangeResponse.from_array(...)
-#  response.postKey     # => String
-#  response.post_key    # => String
-#  response.error       # => String
-#
-class CreateResponse < Struct.new(:postKey, :error, :errors) do
-    def post_key
-      postKey
+module ThreeTaps
+  # Class CreateResponse represents server response on +create+ Posting API
+  # request. Server response is sent to +from_array+ method which creates objects
+  # with attributes +postKey+, +error+ accessible via getters:
+  #
+  #  response = RangeResponse.from_array(...)
+  #  response.postKey     # => String
+  #  response.post_key    # => String
+  #  response.error       # => String
+  #
+  class CreateResponse < Struct.new(:postKey, :error, :errors) do
+      def post_key
+        postKey
+      end
     end
-  end
 
-  # Method +from_array+ creates an array of CreateResponse objects from a given
-  # array of JSON hashes.
-  def self.from_array(array)
-    array.collect do |element|
-      CreateResponse.from_hash(element)
+    # Method +from_array+ creates an array of CreateResponse objects from a given
+    # array of JSON hashes.
+    def self.from_array(array)
+      array.collect do |element|
+        CreateResponse.from_hash(element)
+      end
     end
   end
 end

--- a/lib/dto/posting/delete_response.rb
+++ b/lib/dto/posting/delete_response.rb
@@ -1,9 +1,11 @@
-# Class DeleteResponse represents server response on +delete+ Posting API
-# request. Server response is sent to +from_hash+ method which creates object
-# with attribute +success+ accessible via getter:
-#
-#  response = DeleteResponse.from_hash("success" => "true")
-#  response.success       # => true
-#
-class DeleteResponse < Struct.new(:success)
+module ThreeTaps
+  # Class DeleteResponse represents server response on +delete+ Posting API
+  # request. Server response is sent to +from_hash+ method which creates object
+  # with attribute +success+ accessible via getter:
+  #
+  #  response = DeleteResponse.from_hash("success" => "true")
+  #  response.success       # => true
+  #
+  class DeleteResponse < Struct.new(:success)
+  end
 end

--- a/lib/dto/posting/exists_response.rb
+++ b/lib/dto/posting/exists_response.rb
@@ -1,16 +1,18 @@
-# NOT USED
-#
-# Class ExistsResponse represents server response on +exists+ Posting API
-# request. Server response is sent to +from_hash+ method which creates object
-# with attribute +success+ accessible via getter:
-#
-#  response = ExistsResponse.from_hash("success" => "true")
-#  response.success       # => true
-#
-class ExistsResponse < Struct.new(:indexed, :postKey, :exists, :failures)
-  def initialize(hash = {})
-    hash.each do |key, value|
-      self.send("#{key}=".to_sym, value )
+module ThreeTaps
+  # NOT USED
+  #
+  # Class ExistsResponse represents server response on +exists+ Posting API
+  # request. Server response is sent to +from_hash+ method which creates object
+  # with attribute +success+ accessible via getter:
+  #
+  #  response = ExistsResponse.from_hash("success" => "true")
+  #  response.success       # => true
+  #
+  class ExistsResponse < Struct.new(:indexed, :postKey, :exists, :failures)
+    def initialize(hash = {})
+      hash.each do |key, value|
+        self.send("#{key}=".to_sym, value )
+      end
     end
   end
 end

--- a/lib/dto/posting/update_response.rb
+++ b/lib/dto/posting/update_response.rb
@@ -1,9 +1,11 @@
-# Class UpdateResponse represents server response on +update+ Posting API
-# request. Server response is sent to +from_hash+ method which creates object
-# with attribute +success+ accessible via getter:
-#
-#  response = UpdateResponse.from_hash("success" => "true")
-#  response.success       # => true
-#
-class UpdateResponse < Struct.new(:success)
+module ThreeTaps
+  # Class UpdateResponse represents server response on +update+ Posting API
+  # request. Server response is sent to +from_hash+ method which creates object
+  # with attribute +success+ accessible via getter:
+  #
+  #  response = UpdateResponse.from_hash("success" => "true")
+  #  response.success       # => true
+  #
+  class UpdateResponse < Struct.new(:success)
+  end
 end

--- a/lib/dto/search/best_match_response.rb
+++ b/lib/dto/search/best_match_response.rb
@@ -1,25 +1,27 @@
-# Class BestMatchResponse represents server response on +best_match+ Search API
-# request. Server response is sent to initializer which creates objects with
-# attributes +category+, +numResults+ accessible via getters:
-# * +category+
-# * +num_results+
-# * +numResults+
-#
-# Examples:
-#
-#  response = BestMatchResponse.new("category" => "VAUT", "numResults" => 20)
-#  response.category     # => "VAUT"
-#  response.numResults   # => 20
-#  response.num_results  # => 20
-#
-class BestMatchResponse < Struct.new(:category, :numResults, :error) do
-    def num_results
-      numResults
+module ThreeTaps
+  # Class BestMatchResponse represents server response on +best_match+ Search API
+  # request. Server response is sent to initializer which creates objects with
+  # attributes +category+, +numResults+ accessible via getters:
+  # * +category+
+  # * +num_results+
+  # * +numResults+
+  #
+  # Examples:
+  #
+  #  response = BestMatchResponse.new("category" => "VAUT", "numResults" => 20)
+  #  response.category     # => "VAUT"
+  #  response.numResults   # => 20
+  #  response.num_results  # => 20
+  #
+  class BestMatchResponse < Struct.new(:category, :numResults, :error) do
+      def num_results
+        numResults
+      end
     end
-  end
-  def initialize(hash = {})
-    hash.each do |key, value|
-      self.send("#{key}=".to_sym, value )
+    def initialize(hash = {})
+      hash.each do |key, value|
+        self.send("#{key}=".to_sym, value )
+      end
     end
   end
 end

--- a/lib/dto/search/count_response.rb
+++ b/lib/dto/search/count_response.rb
@@ -1,9 +1,11 @@
-# Class CountResponse represents server response on +count+ Search API
-# request. Server response is sent to initializer which creates objects with
-# attribute +count+ accessible via getter:
-#
-#  response = CountResponse.new("count" => 20)
-#  response.count  # => 20
-#
-class CountResponse < Struct.new(:count)
+module ThreeTaps
+  # Class CountResponse represents server response on +count+ Search API
+  # request. Server response is sent to initializer which creates objects with
+  # attribute +count+ accessible via getter:
+  #
+  #  response = CountResponse.new("count" => 20)
+  #  response.count  # => 20
+  #
+  class CountResponse < Struct.new(:count)
+  end
 end

--- a/lib/dto/search/range_request.rb
+++ b/lib/dto/search/range_request.rb
@@ -1,23 +1,25 @@
-# Returns the minium and maximum values currently in 3taps for the given fields
-# that match the given Common Search Criteria. The purpose of the range method
-# is to provide developers with sensible values for range-based UI filters.
-#
-# range_request = RangeRequest.new
-# search_request = SearchRequest.new
-# search_request.category = 'VAUT'
-# search_request.annotations = {:Make => "porsche"}
-# range_request.search_request = search_request
-# range_request.fields = ['year', 'price']
-#
-class RangeRequest < Struct.new(:search_request, :fields)
+module ThreeTaps
+  # Returns the minium and maximum values currently in 3taps for the given fields
+  # that match the given Common Search Criteria. The purpose of the range method
+  # is to provide developers with sensible values for range-based UI filters.
+  #
+  # range_request = RangeRequest.new
+  # search_request = SearchRequest.new
+  # search_request.category = 'VAUT'
+  # search_request.annotations = {:Make => "porsche"}
+  # range_request.search_request = search_request
+  # range_request.fields = ['year', 'price']
+  #
+  class RangeRequest < Struct.new(:search_request, :fields)
 
-  def add_field(field)
-    fields << field
-  end
+    def add_field(field)
+      fields << field
+    end
 
-  def query_params
-    query_params = search_request.query_params
-    query_params += "fields=#{CGI.escape(fields.join(','))}"
-    query_params
+    def query_params
+      query_params = search_request.query_params
+      query_params += "fields=#{CGI.escape(fields.join(','))}"
+      query_params
+    end
   end
 end

--- a/lib/dto/search/range_response.rb
+++ b/lib/dto/search/range_response.rb
@@ -1,26 +1,28 @@
-# Class RangeResponse represents server response on +range+ Search API
-# request. Server response is sent to +from_array+ method which creates objects
-# with attribute +ranges+ accessible via getter:
-#
-#  response = RangeResponse.from_array(...)
-#  response.ranges     # => Array
-#
-class RangeResponse < Struct.new(:ranges) 
-  
-  # Class Range represents elements of server response on +range+ Search API
-  # request. Server response is sent to initializer which creates object
-  # with attributes +field+, +min+, +max+ accessible via getters:
+module ThreeTaps
+  # Class RangeResponse represents server response on +range+ Search API
+  # request. Server response is sent to +from_array+ method which creates objects
+  # with attribute +ranges+ accessible via getter:
   #
-  #  range = Range.new(...)
-  #  range.field   # => Array
-  #  range.min     # => 10
-  #  range.max     # => 20
+  #  response = RangeResponse.from_array(...)
+  #  response.ranges     # => Array
   #
-  class Range < Struct.new(:field, :min, :max)
-  end
+  class RangeResponse < Struct.new(:ranges) 
+    
+    # Class Range represents elements of server response on +range+ Search API
+    # request. Server response is sent to initializer which creates object
+    # with attributes +field+, +min+, +max+ accessible via getters:
+    #
+    #  range = Range.new(...)
+    #  range.field   # => Array
+    #  range.min     # => 10
+    #  range.max     # => 20
+    #
+    class Range < Struct.new(:field, :min, :max)
+    end
 
-  # Method +from_array+ creates RangeResponse object with a set of Range objects.
-  def self.from_array(json)
-    self.from_hash(:ranges => json.collect { |key, value| Range.from_hash( :field => key, :max => value["max"], :min => value["min"])})
+    # Method +from_array+ creates RangeResponse object with a set of Range objects.
+    def self.from_array(json)
+      self.from_hash(:ranges => json.collect { |key, value| Range.from_hash( :field => key, :max => value["max"], :min => value["min"])})
+    end
   end
 end

--- a/lib/dto/search/search_request.rb
+++ b/lib/dto/search/search_request.rb
@@ -1,79 +1,81 @@
-class SearchRequest
-  # annotations attribute should be a Hash object
-  attr_accessor :rpp, :page, :source, :category, :location, :heading,
-    :body, :text, :external_id, :start, :end, :annotations,
-    :trusted_annotations, :retvals
+module ThreeTaps  
+  class SearchRequest
+    # annotations attribute should be a Hash object
+    attr_accessor :rpp, :page, :source, :category, :location, :heading,
+      :body, :text, :external_id, :start, :end, :annotations,
+      :trusted_annotations, :retvals
 
-  def add_retval(retval)
-    @retvals << retval
-  end
-
-  def query_params
-    query = Hash.new
-    url_params = ''
-    if (rpp != nil)
-      query[:rpp] = rpp.to_s;
-      url_params += "rpp=#{CGI.escape(query[:rpp])}&"
-    end
-    if (page != nil)
-      query[:page] = page.to_s;
-      url_params += "page=#{CGI.escape(query[:page])}&"
-    end
-    if (source != nil)
-      query[:source] = source.to_s;
-      url_params += "source=#{CGI.escape(query[:source])}&"
-    end
-    if (category != nil)
-      query[:category] = category.to_s;
-      url_params += "category=#{CGI.escape(query[:category])}&"
-    end
-    if (location != nil)
-      query[:location] = location.to_s;
-      url_params += "location=#{CGI.escape(query[:location])}&"
-    end
-    if (heading != nil)
-      query[:heading] = heading.to_s;
-      url_params += "heading=#{CGI.escape(query[:heading])}&"
-    end
-    if (body != nil)
-      query[:body] = body.to_s;
-      url_params += "body=#{CGI.escape(query[:body])}&"
-    end
-    if (text != nil)
-      query[:text] = text.to_s;
-      url_params += "text=#{CGI.escape(query[:text])}&"
-    end
-    if (external_id != nil)
-      query[:external_id] = external_id.to_s;
-      url_params += "external_id=#{CGI.escape(query[:external_id])}&"
-    end
-    if (start != nil)
-      query[:start] = start.to_s;
-      url_params += "start=#{CGI.escape(query[:start])}&"
-    end
-    if (self.end != nil)
-      query[:end] = self.end.to_s;
-      url_params += "end=#{CGI.escape(query[:end])}&"
+    def add_retval(retval)
+      @retvals << retval
     end
 
-    if (annotations != nil && annotations.size > 0)
-#      query[:annotations] = ActiveSupport::JSON.encode(annotations)
-      query[:annotations] = annotations
-#      query.each do |key, value|
-#        url_params += "#{key}=#{value}&"
-#      end
-      url_params += "annotations=#{CGI.escape(ActiveSupport::JSON.encode(query[:annotations]))}&" #'annotations=#{CGI.escape(ActiveSupport::JSON.encode(search.annotations))}'
+    def query_params
+      query = Hash.new
+      url_params = ''
+      if (rpp != nil)
+        query[:rpp] = rpp.to_s;
+        url_params += "rpp=#{CGI.escape(query[:rpp])}&"
+      end
+      if (page != nil)
+        query[:page] = page.to_s;
+        url_params += "page=#{CGI.escape(query[:page])}&"
+      end
+      if (source != nil)
+        query[:source] = source.to_s;
+        url_params += "source=#{CGI.escape(query[:source])}&"
+      end
+      if (category != nil)
+        query[:category] = category.to_s;
+        url_params += "category=#{CGI.escape(query[:category])}&"
+      end
+      if (location != nil)
+        query[:location] = location.to_s;
+        url_params += "location=#{CGI.escape(query[:location])}&"
+      end
+      if (heading != nil)
+        query[:heading] = heading.to_s;
+        url_params += "heading=#{CGI.escape(query[:heading])}&"
+      end
+      if (body != nil)
+        query[:body] = body.to_s;
+        url_params += "body=#{CGI.escape(query[:body])}&"
+      end
+      if (text != nil)
+        query[:text] = text.to_s;
+        url_params += "text=#{CGI.escape(query[:text])}&"
+      end
+      if (external_id != nil)
+        query[:external_id] = external_id.to_s;
+        url_params += "external_id=#{CGI.escape(query[:external_id])}&"
+      end
+      if (start != nil)
+        query[:start] = start.to_s;
+        url_params += "start=#{CGI.escape(query[:start])}&"
+      end
+      if (self.end != nil)
+        query[:end] = self.end.to_s;
+        url_params += "end=#{CGI.escape(query[:end])}&"
+      end
+
+      if (annotations != nil && annotations.size > 0)
+  #      query[:annotations] = ActiveSupport::JSON.encode(annotations)
+        query[:annotations] = annotations
+  #      query.each do |key, value|
+  #        url_params += "#{key}=#{value}&"
+  #      end
+        url_params += "annotations=#{CGI.escape(ActiveSupport::JSON.encode(query[:annotations]))}&" #'annotations=#{CGI.escape(ActiveSupport::JSON.encode(search.annotations))}'
+      end
+      if (trusted_annotations != nil && trusted_annotations.size > 0)
+        #query[:trusted_annotations] = ActiveSupport::JSON.encode(trusted_annotations)
+        query[:trusted_annotations] = trusted_annotations
+        url_params += "trusted_annotations=#{CGI.escape(ActiveSupport::JSON.encode(query[:trusted_annotations]))}&"
+      end
+      if (retvals != nil)
+        query[:retvals] = retvals.join(',')  #queryParams.put("retvals", Utils.join(retvals));
+        url_params += "retvals=#{CGI.escape(query[:retvals])}&"
+      end
+      
+      url_params
     end
-    if (trusted_annotations != nil && trusted_annotations.size > 0)
-      #query[:trusted_annotations] = ActiveSupport::JSON.encode(trusted_annotations)
-      query[:trusted_annotations] = trusted_annotations
-      url_params += "trusted_annotations=#{CGI.escape(ActiveSupport::JSON.encode(query[:trusted_annotations]))}&"
-    end
-    if (retvals != nil)
-      query[:retvals] = retvals.join(',')  #queryParams.put("retvals", Utils.join(retvals));
-      url_params += "retvals=#{CGI.escape(query[:retvals])}&"
-    end
-    
-    url_params
   end
 end

--- a/lib/dto/search/search_response.rb
+++ b/lib/dto/search/search_response.rb
@@ -1,37 +1,39 @@
-# Class SearchResponse represents server response on +search+ Search API
-# request. Server response is sent to initializer which creates object with
-# attributes +success+, +numResults+, +execTimeMs+, +results+ accessible via getters:
-# * +success+
-# * +num_results+
-# * +numResults+
-# * +execTimeMs+
-# * +exec_time_ms+
-# * +results+
-#
-# Examples:
-#
-#  response = SearchResponse.new("success" => "true", "numResults" => 0, "execTimeMs" => 100, "results" => [])
-#  response.category     # => "VAUT"
-#  response.numResults   # => 0
-#  response.num_results  # => 0
-#  response.execTimeMs   # => 100
-#  response.exec_time_ms # => 100
-#  response.results      # => []
-#
-class SearchResponse < Struct.new(:success, :numResults, :execTimeMs, :results) do
-    def num_results
-      numResults
+module ThreeTaps
+  # Class SearchResponse represents server response on +search+ Search API
+  # request. Server response is sent to initializer which creates object with
+  # attributes +success+, +numResults+, +execTimeMs+, +results+ accessible via getters:
+  # * +success+
+  # * +num_results+
+  # * +numResults+
+  # * +execTimeMs+
+  # * +exec_time_ms+
+  # * +results+
+  #
+  # Examples:
+  #
+  #  response = SearchResponse.new("success" => "true", "numResults" => 0, "execTimeMs" => 100, "results" => [])
+  #  response.category     # => "VAUT"
+  #  response.numResults   # => 0
+  #  response.num_results  # => 0
+  #  response.execTimeMs   # => 100
+  #  response.exec_time_ms # => 100
+  #  response.results      # => []
+  #
+  class SearchResponse < Struct.new(:success, :numResults, :execTimeMs, :results) do
+      def num_results
+        numResults
+      end
+      def exec_time_ms
+        execTimeMs
+      end
     end
-    def exec_time_ms
-      execTimeMs
-    end
-  end
 
-  # Initializer receives hash as a parameter and fills object fields from it. 
-  # +results+ field is filled with array of Posting objects.
-  def initialize(hash = {})
-    hash.each do |key, value|
-      self.send("#{key}=".to_sym, key == 'results' ? value.collect {|item| Posting.new(item)} : value )
+    # Initializer receives hash as a parameter and fills object fields from it. 
+    # +results+ field is filled with array of Posting objects.
+    def initialize(hash = {})
+      hash.each do |key, value|
+        self.send("#{key}=".to_sym, key == 'results' ? value.collect {|item| Posting.new(item)} : value )
+      end
     end
   end
 end

--- a/lib/dto/search/summary_request.rb
+++ b/lib/dto/search/summary_request.rb
@@ -1,13 +1,15 @@
-#private SearchRequest searchRequest;
-#private String dimension;
-class SummaryRequest
-  attr_accessor :search_request, :dimension
-  
-  def query_params
-    query_params = ''
-    query_params = "dimension=#{CGI.escape(dimension)}&" if (dimension != nil)
-    query_params += search_request.query_params if (search_request != nil)
-    query_params
-  end
+module ThreeTaps
+  #private SearchRequest searchRequest;
+  #private String dimension;
+  class SummaryRequest
+    attr_accessor :search_request, :dimension
+    
+    def query_params
+      query_params = ''
+      query_params = "dimension=#{CGI.escape(dimension)}&" if (dimension != nil)
+      query_params += search_request.query_params if (search_request != nil)
+      query_params
+    end
 
+  end
 end

--- a/lib/dto/search/summary_response.rb
+++ b/lib/dto/search/summary_response.rb
@@ -1,20 +1,22 @@
-# Class SummaryResponse represents server response on +summary+ Search API
-# request. Server response is sent to initializer which creates object with
-# attributes +totals+, +execTimeMs+ accessible via getters:
-# * +totals+
-# * +execTimeMs+
-# * +exec_time_ms+
-#
-# Examples:
-#
-#  response = SummaryResponse.new("totals" => 20, "execTimeMs" => 100)
-#  response.totals       # => 20
-#  response.execTimeMs   # => 100
-#  response.exec_time_ms # => 100
-#
-class SummaryResponse < Struct.new(:totals, :execTimeMs) do
-    def exec_time_ms
-      execTimeMs
+module ThreeTaps
+  # Class SummaryResponse represents server response on +summary+ Search API
+  # request. Server response is sent to initializer which creates object with
+  # attributes +totals+, +execTimeMs+ accessible via getters:
+  # * +totals+
+  # * +execTimeMs+
+  # * +exec_time_ms+
+  #
+  # Examples:
+  #
+  #  response = SummaryResponse.new("totals" => 20, "execTimeMs" => 100)
+  #  response.totals       # => 20
+  #  response.execTimeMs   # => 100
+  #  response.exec_time_ms # => 100
+  #
+  class SummaryResponse < Struct.new(:totals, :execTimeMs) do
+      def exec_time_ms
+        execTimeMs
+      end
     end
   end
 end

--- a/lib/dto/status/get_status_response.rb
+++ b/lib/dto/status/get_status_response.rb
@@ -1,42 +1,44 @@
-# Class GetStatusResponse represents server response on +get_status+ Status API
-# request. Server response is sent to +from_array+ method which creates objects
-# attributes +exists+, +externalID+, +source+, +history+ accessible via getters:
-# * +exists+
-# * +externalID+
-# * +source+
-# * +history+
-#
-# Example:
-#
-#  response = GetStatusResponse.from_array(...)    # => Array
-#
-class GetStatusResponse < Struct.new(:exists, :externalID, :source, :history)
-  # Class Status represents elements of server response on +get_status+ Status API
-  # request. Server response is sent to initializer which creates object
-  # with attributes +field+, +attrs+ accessible via getters:
+module ThreeTaps
+  # Class GetStatusResponse represents server response on +get_status+ Status API
+  # request. Server response is sent to +from_array+ method which creates objects
+  # attributes +exists+, +externalID+, +source+, +history+ accessible via getters:
+  # * +exists+
+  # * +externalID+
+  # * +source+
+  # * +history+
   #
-  #  status = Status.new(...)
-  #  status.field     # => Array
-  #  status.attrs     # => Array of Attr
+  # Example:
   #
-  class Status < Struct.new(:field, :attrs)
-  end
-  # Class Attr represents elements of server response on +get_status+ Status API
-  # request. Server response is sent to initializer which creates object
-  # with attributes +timestamp+, +errors+, +attributes+ accessible via getters:
+  #  response = GetStatusResponse.from_array(...)    # => Array
   #
-  #  attr = Attr.new(...)
-  #
-  class Attr < Struct.new(:timestamp, :errors, :attributes)
-  end
-  # Method +from_array+ creates GetStatusResponse object
-  def self.from_array(json)
-     json.each do |hash|
-      hash.each do |key, value|
-        self.new("#{key}=".to_sym, key == 'history' ?  value.collect {
-          |key, items| Status.new(:field => key, :attrs => items.collect {|item| 
-           Attr.new(:timestamp => item["timestamp"], :errors => item["errors"], :attributes => item["attributes"]) }
-          )} : value )
+  class GetStatusResponse < Struct.new(:exists, :externalID, :source, :history)
+    # Class Status represents elements of server response on +get_status+ Status API
+    # request. Server response is sent to initializer which creates object
+    # with attributes +field+, +attrs+ accessible via getters:
+    #
+    #  status = Status.new(...)
+    #  status.field     # => Array
+    #  status.attrs     # => Array of Attr
+    #
+    class Status < Struct.new(:field, :attrs)
+    end
+    # Class Attr represents elements of server response on +get_status+ Status API
+    # request. Server response is sent to initializer which creates object
+    # with attributes +timestamp+, +errors+, +attributes+ accessible via getters:
+    #
+    #  attr = Attr.new(...)
+    #
+    class Attr < Struct.new(:timestamp, :errors, :attributes)
+    end
+    # Method +from_array+ creates GetStatusResponse object
+    def self.from_array(json)
+       json.each do |hash|
+        hash.each do |key, value|
+          self.new("#{key}=".to_sym, key == 'history' ?  value.collect {
+            |key, items| Status.new(:field => key, :attrs => items.collect {|item| 
+             Attr.new(:timestamp => item["timestamp"], :errors => item["errors"], :attributes => item["attributes"]) }
+            )} : value )
+        end
       end
     end
   end

--- a/lib/dto/status/status_update_request.rb
+++ b/lib/dto/status/status_update_request.rb
@@ -1,27 +1,29 @@
-# Class StatusUpdateRequest returns the correct string for request 3taps
-# 
-class StatusUpdateRequest < Struct.new(:event, :timestump, :attributes, :errors)  
-  #
-  # Method +to_params+ creates the correct string for request 3taps.
-  #
-  def to_params
-    data =  "status:'#{event}'"
-    data <<  ", timestump:'#{((timestump).utc.to_s(:db)).gsub(/\s/,"+")}'" if timestump
-    data <<  ", attributes:{#{attributes_for_params}}" unless attributes.empty?
-    data <<  ", errors:[#{errors_for_params}]" unless errors.empty?
-    data
-  end
-  #
-  # Method +attributes_for_params+ creates array attributes for params.
-  #
-  def attributes_for_params
-    attributes.collect{ |key, value| "#{key}:'#{CGI.escape value}'"  }.join(", ")
-  end
-  #
-  # Method +errors_for_params+ array errors for params.
-  #
-  def errors_for_params
-    errors.collect{ |error| "{code:#{error.code}, message:'#{CGI.escape error.message}'}" }.join(", ")
-  end
+module ThreeTaps
+  # Class StatusUpdateRequest returns the correct string for request 3taps
+  # 
+  class StatusUpdateRequest < Struct.new(:event, :timestump, :attributes, :errors)  
+    #
+    # Method +to_params+ creates the correct string for request 3taps.
+    #
+    def to_params
+      data =  "status:'#{event}'"
+      data <<  ", timestump:'#{((timestump).utc.to_s(:db)).gsub(/\s/,"+")}'" if timestump
+      data <<  ", attributes:{#{attributes_for_params}}" unless attributes.empty?
+      data <<  ", errors:[#{errors_for_params}]" unless errors.empty?
+      data
+    end
+    #
+    # Method +attributes_for_params+ creates array attributes for params.
+    #
+    def attributes_for_params
+      attributes.collect{ |key, value| "#{key}:'#{CGI.escape value}'"  }.join(", ")
+    end
+    #
+    # Method +errors_for_params+ array errors for params.
+    #
+    def errors_for_params
+      errors.collect{ |error| "{code:#{error.code}, message:'#{CGI.escape error.message}'}" }.join(", ")
+    end
 
+  end
 end

--- a/lib/models/annotations/annotation.rb
+++ b/lib/models/annotations/annotation.rb
@@ -1,21 +1,23 @@
-# Class Annotation represents structure of annotation
-#
-#  annotation = Annotation.new
-#  annotation.name            # => String
-#  annotation.annotation_type # => String
-#  annotation.options         # => Array of AnnotationOption objects
-#
-class Annotation < SuperModel::Base
-  attributes :name, :annotation_type, :options
-
-  # Class AnnotaionType represents container of constants of annotation types:
-  #  SELECT = 1
-  #  STRING = 2
-  #  NUMBER = 3
+module ThreeTaps
+  # Class Annotation represents structure of annotation
   #
-  class AnnotaionType
-    SELECT = 1
-    STRING = 2
-    NUMBER = 3
+  #  annotation = Annotation.new
+  #  annotation.name            # => String
+  #  annotation.annotation_type # => String
+  #  annotation.options         # => Array of AnnotationOption objects
+  #
+  class Annotation < SuperModel::Base
+    attributes :name, :annotation_type, :options
+
+    # Class AnnotaionType represents container of constants of annotation types:
+    #  SELECT = 1
+    #  STRING = 2
+    #  NUMBER = 3
+    #
+    class AnnotaionType
+      SELECT = 1
+      STRING = 2
+      NUMBER = 3
+    end
   end
 end

--- a/lib/models/annotations/annotation_option.rb
+++ b/lib/models/annotations/annotation_option.rb
@@ -1,9 +1,11 @@
-# Class AnnotationOption represents structure of options
-#
-#  option = AnnotationOption.new
-#  option.value          # => String
-#  option.sub_annotation # => String
-#
-class AnnotationOption < SuperModel::Base
-  attributes :value, :sub_annotation
+module ThreeTaps
+  # Class AnnotationOption represents structure of options
+  #
+  #  option = AnnotationOption.new
+  #  option.value          # => String
+  #  option.sub_annotation # => String
+  #
+  class AnnotationOption < SuperModel::Base
+    attributes :value, :sub_annotation
+  end
 end

--- a/lib/models/category.rb
+++ b/lib/models/category.rb
@@ -1,26 +1,28 @@
-# Class Category represents structure of category:
-#
-#  category = Category.new
-#  category.code        # => String
-#  category.group       # => String
-#  category.category    # => String
-#  category.hidden      # => Boolean
-#  category.annotations # => Array of Annotation objects
+module ThreeTaps
+  # Class Category represents structure of category:
+  #
+  #  category = Category.new
+  #  category.code        # => String
+  #  category.group       # => String
+  #  category.category    # => String
+  #  category.hidden      # => Boolean
+  #  category.annotations # => Array of Annotation objects
 
-#  category.from_array(array) # =>  Array of Category objects
-#
-class Category < Struct.new(:group, :category, :code, :annotations, :hidden)
+  #  category.from_array(array) # =>  Array of Category objects
+  #
+  class Category < Struct.new(:group, :category, :code, :annotations, :hidden)
 
-  # Method +from_array+ returns array of categories(create from json).
-  # Takes value of array objects as json parameter array.
-  #
-  # Example:
-  #
-  #  Category.from_array([...array of JSON objects...]) # => Array of Category
-  #
-  def self.from_array(array)
-    array.collect do |element|
-      Category.new(element)
+    # Method +from_array+ returns array of categories(create from json).
+    # Takes value of array objects as json parameter array.
+    #
+    # Example:
+    #
+    #  Category.from_array([...array of JSON objects...]) # => Array of Category
+    #
+    def self.from_array(array)
+      array.collect do |element|
+        Category.new(element)
+      end
     end
   end
 end

--- a/lib/models/location.rb
+++ b/lib/models/location.rb
@@ -1,37 +1,39 @@
-# Class Location represents structure of location:
-#
-#  location = Location.new
-#  location.countryRank # => Integer
-#  location.country     # => String
-#  location.cityRank    # => Integer
-#  location.city        # => String
-#  location.stateCode   # => String
-#  location.stateName   # => String
-#  location.code        # => String
-#  location.latitude    # => Float
-#  location.longitude   # => Float
-#
-#  location.from_array(array) # =>  Array of Location objects
-#
-class Location < Struct.new(:countryRank, :country, :cityRank, :city, :stateCode, :stateName, :code, :latitude, :longitude)
-  
-  #allows initialization of a new struct with an attribute hash
-  def initialize(attributes = {})
-    attributes.each do |key, value|
-      self[key] = value
+module ThreeTaps
+  # Class Location represents structure of location:
+  #
+  #  location = Location.new
+  #  location.countryRank # => Integer
+  #  location.country     # => String
+  #  location.cityRank    # => Integer
+  #  location.city        # => String
+  #  location.stateCode   # => String
+  #  location.stateName   # => String
+  #  location.code        # => String
+  #  location.latitude    # => Float
+  #  location.longitude   # => Float
+  #
+  #  location.from_array(array) # =>  Array of Location objects
+  #
+  class Location < Struct.new(:countryRank, :country, :cityRank, :city, :stateCode, :stateName, :code, :latitude, :longitude)
+    
+    #allows initialization of a new struct with an attribute hash
+    def initialize(attributes = {})
+      attributes.each do |key, value|
+        self[key] = value
+      end
     end
-  end
-  
-  # Method +from_array+ returns array of locations(create from json).
-  # Takes value of array objects as json parameter array.
-  #
-  # Example:
-  #
-  #  Location.from_array([...array of JSON objects...]) # => Array of Location
-  #
-  def self.from_array(array)
-    array.collect do |element|
-      Location.new(element)
+    
+    # Method +from_array+ returns array of locations(create from json).
+    # Takes value of array objects as json parameter array.
+    #
+    # Example:
+    #
+    #  Location.from_array([...array of JSON objects...]) # => Array of Location
+    #
+    def self.from_array(array)
+      array.collect do |element|
+        Location.new(element)
+      end
     end
   end
 end

--- a/lib/models/message.rb
+++ b/lib/models/message.rb
@@ -1,9 +1,11 @@
-# Class Message represents structure of message
-#
-#  message = Message.new
-#  message.code    # => Integer
-#  message.message # => String
-#
-class Message < Struct.new(:code, :message)
+module ThreeTaps
+  # Class Message represents structure of message
+  #
+  #  message = Message.new
+  #  message.code    # => Integer
+  #  message.message # => String
+  #
+  class Message < Struct.new(:code, :message)
 
+  end
 end

--- a/lib/models/posting.rb
+++ b/lib/models/posting.rb
@@ -1,110 +1,112 @@
-# Class Posting represents structure of posting:
-#
-#  posting = Posting.new
-#  posting.postKey            # => String
-#  posting.heading            # => String
-#  posting.body               # => String
-#  posting.category           # => Boolean
-#  posting.source             # => Array of Annotation objects
-#  posting.location           # => String
-#  posting.longitude          # => Float
-#  posting.latitude           # => Float
-#  posting.language           # => String
-#  posting.price              # => String
-#  posting.currency           # => String
-#  posting.images             # => Array of String objects
-#  posting.externalURL        # => String
-##  posting.externalID         # => String
-#  posting.accountName        # => String
-#  posting.accountID          # => String
-#  posting.clickCount         # => Integer
-#  posting.timestamp          # => Date
-#  posting.expiration         # => Date
-#  posting.indexed            # => Date
-#  posting.trustedAnnotations # => Array of Annotation objects
-#  posting.annotations        # => Array of Annotation objects
-#  posting.errors             # => Array of String objects
-#  posting.status             # => String
-#  posting.history            # => String
+module ThreeTaps
+  # Class Posting represents structure of posting:
+  #
+  #  posting = Posting.new
+  #  posting.postKey            # => String
+  #  posting.heading            # => String
+  #  posting.body               # => String
+  #  posting.category           # => Boolean
+  #  posting.source             # => Array of Annotation objects
+  #  posting.location           # => String
+  #  posting.longitude          # => Float
+  #  posting.latitude           # => Float
+  #  posting.language           # => String
+  #  posting.price              # => String
+  #  posting.currency           # => String
+  #  posting.images             # => Array of String objects
+  #  posting.externalURL        # => String
+  ##  posting.externalID         # => String
+  #  posting.accountName        # => String
+  #  posting.accountID          # => String
+  #  posting.clickCount         # => Integer
+  #  posting.timestamp          # => Date
+  #  posting.expiration         # => Date
+  #  posting.indexed            # => Date
+  #  posting.trustedAnnotations # => Array of Annotation objects
+  #  posting.annotations        # => Array of Annotation objects
+  #  posting.errors             # => Array of String objects
+  #  posting.status             # => String
+  #  posting.history            # => String
 
-#  posting.to_json                   # => Array of JSON objects
-#  posting.to_json_for_update        # => Array of JSON objects
-#  posting.to_json_for_status_client # => Array of JSON objects
-#  posting.to_json_for_status        # => Array of JSON objects
-class Posting < SuperModel::Base
-  attributes :postKey, :heading, :body, :category, :source, :location,
-    :longitude, :latitude, :language, :price, :currency, :images,
-    :externalURL, :externalID, :accountName, :accountID, :clickCount,
-    :timestamp, :expiration, :indexed, :trustedAnnotations,
-    :annotations, :errors, :status, :history
-  def initialize(*params)
-    super(*params)
-    @attributes[:images] ||= []
-    @attributes[:annotations] ||= {}
-    @attributes[:status] ||= StatusUpdateRequest.from_hash(:event => '', :timestump => nil, :attributes => {}, :errors => [])
-  end
-
-  def to_json
-    posting = "{"+'source:'+"'#{self.source}'" + ',category:' + "'#{self.category}'" + ',location:' + "'#{self.location}'" + ',heading:' +  "'#{self.heading.to_s[0,254]}'"
-    if self.timestamp
-      posting << ",timestamp: '#{(Time.at(self.timestamp).utc.to_s(:db)).gsub("-","/")}'"
-    else
-      posting << ",timestamp: '#{(Time.now.utc.to_s(:db)).gsub("-","/")}'"
+  #  posting.to_json                   # => Array of JSON objects
+  #  posting.to_json_for_update        # => Array of JSON objects
+  #  posting.to_json_for_status_client # => Array of JSON objects
+  #  posting.to_json_for_status        # => Array of JSON objects
+  class Posting < SuperModel::Base
+    attributes :postKey, :heading, :body, :category, :source, :location,
+      :longitude, :latitude, :language, :price, :currency, :images,
+      :externalURL, :externalID, :accountName, :accountID, :clickCount,
+      :timestamp, :expiration, :indexed, :trustedAnnotations,
+      :annotations, :errors, :status, :history
+    def initialize(*params)
+      super(*params)
+      @attributes[:images] ||= []
+      @attributes[:annotations] ||= {}
+      @attributes[:status] ||= StatusUpdateRequest.from_hash(:event => '', :timestump => nil, :attributes => {}, :errors => [])
     end
-    posting << ',images:' + "[#{images.collect{ |image| "'#{image}'"}.join(',')}]"
-    unless self.body.blank?
-      self.body.gsub!(/[&']/,"")
-      #self.body.gsub!(/\s*<[^>]*>/,"")
-      posting << ',body:' + "'#{ActiveSupport::JSON.encode(self.body)}'"
-    end
-    posting <<  ',price:' + "#{self.price.to_f}"
-    posting <<  ',currency:' + "'#{self.currency}'"
-    posting <<  ',accountName:' + "'#{self.accountName}'"
-    posting <<  ',accountID:' + "'#{self.accountID}'"
-    posting <<  ',externalURL:' + "'#{self.externalURL}'"
-    posting <<  ',externalID:' + "'#{self.externalID}'"
-    if self.annotations
-      annotations = []
-      self.annotations.each{|k,v| annotations << "#{k}:" + "'#{v}'"}
-      posting << ',annotations:' + "{#{annotations.join(',')}}"
-    end
-    posting  +  "}"
-  end
 
-  def to_json_for_update
-    data = "['#{self.postKey}',"
-    data << "{heading:"+  "'#{self.heading}'"  unless self.heading.blank?
-    data << ",images:" + "[#{images.collect{ |image| "'#{image}'"}.join(',')}]"
-    data << ",source:'#{self.source}'" unless self.source.blank?
-    data << ",category:'#{self.category}'" unless self.category.blank?
-    data << ",location:'#{self.location}'" unless self.location.blank?
-    data << ",body:" + "'#{self.body}'" unless self.body.blank?
-    data <<  ',price:' + "'#{self.price}'"
-    data <<  ',currency:' + "'#{self.currency}'"
-    data <<  ',accountName:' + "'#{self.accountName}'"
-    data <<  ',accountID:' + "'#{self.accountID}'"
-    data <<  ',externalURL:' + "'#{self.externalURL}'"
-    data <<  ',externalID:' + "'#{self.externalID}'"
-    if self.annotations
-      annotations = []
-      self.annotations.each{|k,v| annotations << "#{k}:" + "'#{v}'"}
-      data << ",annotations:" + "{#{annotations.join(',')}}"
+    def to_json
+      posting = "{"+'source:'+"'#{self.source}'" + ',category:' + "'#{self.category}'" + ',location:' + "'#{self.location}'" + ',heading:' +  "'#{self.heading.to_s[0,254]}'"
+      if self.timestamp
+        posting << ",timestamp: '#{(Time.at(self.timestamp).utc.to_s(:db)).gsub("-","/")}'"
+      else
+        posting << ",timestamp: '#{(Time.now.utc.to_s(:db)).gsub("-","/")}'"
+      end
+      posting << ',images:' + "[#{images.collect{ |image| "'#{image}'"}.join(',')}]"
+      unless self.body.blank?
+        self.body.gsub!(/[&']/,"")
+        #self.body.gsub!(/\s*<[^>]*>/,"")
+        posting << ',body:' + "'#{ActiveSupport::JSON.encode(self.body)}'"
+      end
+      posting <<  ',price:' + "#{self.price.to_f}"
+      posting <<  ',currency:' + "'#{self.currency}'"
+      posting <<  ',accountName:' + "'#{self.accountName}'"
+      posting <<  ',accountID:' + "'#{self.accountID}'"
+      posting <<  ',externalURL:' + "'#{self.externalURL}'"
+      posting <<  ',externalID:' + "'#{self.externalID}'"
+      if self.annotations
+        annotations = []
+        self.annotations.each{|k,v| annotations << "#{k}:" + "'#{v}'"}
+        posting << ',annotations:' + "{#{annotations.join(',')}}"
+      end
+      posting  +  "}"
     end
-    data << "}"
-    data << "]"
-  end
 
-  def to_json_for_status
-    # {source: 'CRAIG', externalID: 3434399120}
-    data = "source:'#{self.source}', " unless self.source.blank?
-    data << "externalID: '#{self.externalID}'" unless self.externalID.blank?
-    data
-  end
-  def to_json_for_status_client
-    # source: 'CRAIG', externalID: 3434399120
-    data = "source:'#{self.source}', " unless self.source.blank?
-    data << "externalID: '#{self.externalID}'" unless self.externalID.blank?
-    data
-  end
+    def to_json_for_update
+      data = "['#{self.postKey}',"
+      data << "{heading:"+  "'#{self.heading}'"  unless self.heading.blank?
+      data << ",images:" + "[#{images.collect{ |image| "'#{image}'"}.join(',')}]"
+      data << ",source:'#{self.source}'" unless self.source.blank?
+      data << ",category:'#{self.category}'" unless self.category.blank?
+      data << ",location:'#{self.location}'" unless self.location.blank?
+      data << ",body:" + "'#{self.body}'" unless self.body.blank?
+      data <<  ',price:' + "'#{self.price}'"
+      data <<  ',currency:' + "'#{self.currency}'"
+      data <<  ',accountName:' + "'#{self.accountName}'"
+      data <<  ',accountID:' + "'#{self.accountID}'"
+      data <<  ',externalURL:' + "'#{self.externalURL}'"
+      data <<  ',externalID:' + "'#{self.externalID}'"
+      if self.annotations
+        annotations = []
+        self.annotations.each{|k,v| annotations << "#{k}:" + "'#{v}'"}
+        data << ",annotations:" + "{#{annotations.join(',')}}"
+      end
+      data << "}"
+      data << "]"
+    end
 
+    def to_json_for_status
+      # {source: 'CRAIG', externalID: 3434399120}
+      data = "source:'#{self.source}', " unless self.source.blank?
+      data << "externalID: '#{self.externalID}'" unless self.externalID.blank?
+      data
+    end
+    def to_json_for_status_client
+      # source: 'CRAIG', externalID: 3434399120
+      data = "source:'#{self.source}', " unless self.source.blank?
+      data << "externalID: '#{self.externalID}'" unless self.externalID.blank?
+      data
+    end
+
+  end
 end

--- a/lib/models/posting_history.rb
+++ b/lib/models/posting_history.rb
@@ -1,8 +1,10 @@
-# Class PostingHistory represents structure of history
-#
-#  history = PostingHistory.new
-#  history.history # => String
-#
-class PostingHistory < Struct.new(:history)
- #include HashedInitializer
+module ThreeTaps
+  # Class PostingHistory represents structure of history
+  #
+  #  history = PostingHistory.new
+  #  history.history # => String
+  #
+  class PostingHistory < Struct.new(:history)
+   #include HashedInitializer
+  end
 end

--- a/lib/models/source.rb
+++ b/lib/models/source.rb
@@ -1,27 +1,29 @@
-# Class Source represents structure of source
-#
-#  source = Source.new
-#  source.name        # => String
-#  source.code        # => String
-#  source.logo_url    # => String
-#  source.logo_sm_url # => String
-#  source.hidden      # => Boolean
-#
-#  source.from_array(array) # =>  Array of Source objects
-#
-class Source < Struct.new(:name, :code, :logo_url, :logo_sm_url, :hidden)
+module ThreeTaps
+  # Class Source represents structure of source
+  #
+  #  source = Source.new
+  #  source.name        # => String
+  #  source.code        # => String
+  #  source.logo_url    # => String
+  #  source.logo_sm_url # => String
+  #  source.hidden      # => Boolean
+  #
+  #  source.from_array(array) # =>  Array of Source objects
+  #
+  class Source < Struct.new(:name, :code, :logo_url, :logo_sm_url, :hidden)
 
 
-  # Method +from_array+ returns array of sources(create from json).
-  # Takes value of array objects as json parameter array.
-  #
-  # Example:
-  #
-  #  Source.from_array([...array of JSON objects...]) # => Array of Source
-  #
-  def self.from_array(array)
-    array.collect do |element|
-      Source.new(element)
+    # Method +from_array+ returns array of sources(create from json).
+    # Takes value of array objects as json parameter array.
+    #
+    # Example:
+    #
+    #  Source.from_array([...array of JSON objects...]) # => Array of Source
+    #
+    def self.from_array(array)
+      array.collect do |element|
+        Source.new(element)
+      end
     end
   end
 end

--- a/lib/threetaps-client.rb
+++ b/lib/threetaps-client.rb
@@ -5,6 +5,10 @@ require 'active_support'
 require 'curb'
 require 'struct'
 
+module ThreeTaps
+  VERSION = '1.0.11'
+end
+
 require 'client/client'
 require 'client/search_client'
 require 'client/posting_client'
@@ -42,3 +46,4 @@ require 'models/posting_history'
 require 'models/source'
 require 'models/annotations/annotation'
 require 'models/annotations/annotation_option'
+

--- a/lib/threetaps-client.rb
+++ b/lib/threetaps-client.rb
@@ -3,7 +3,8 @@ require 'cgi'
 require 'supermodel'
 require 'active_support'
 require 'curb'
-require 'struct'
+#require 'struct'
+$:.push File.dirname(__FILE__)
 
 module ThreeTaps
   VERSION = '1.0.11'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'rspec'
 require 'supermodel'
 require 'curb'
 require 'threetaps-client'
+include ThreeTaps
+
 require 'cgi'
 
 # Requires supporting files with custom matchers and macros, etc,

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,6 +13,7 @@ require 'shoulda'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'threetaps-client'
+require ThreeTaps
 
 class Test::Unit::TestCase
 end


### PR DESCRIPTION
Right now, the 3Taps Ruby Client pollutes the global namespace with classes like "Message" and "Location", which makes is unusable in any non-trivial project. This pull request moves everything to the ThreeTaps module. If users want to stick everything in the global namespace, they just need to "include ThreeTaps" after they require the library.

Testing done: ran rake spec; got no failures. 
